### PR TITLE
Code Rewrite + Three Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I've been increasingly frustrated with the balance of Survival mode, especially 
 ### Renaming
 
 - Renaming now has a flat cost of 2 XP.
+- Renaming when you cannot perform an item merge is no longer possible (to stop deletion of said item).
 
 ### Optional: Mending Rebalance
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.22
 # Mod Properties
-mod_version=Alpha-1.0.2
+mod_version=Alpha-1.1.0
 maven_group=com.googlerooeric
 archives_base_name=anvilfix
 # Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19
 yarn_mappings=1.19+build.4
 loader_version=0.14.22
 # Mod Properties
-mod_version=Alpha-1.0.1
+mod_version=Alpha-1.0.2
 maven_group=com.googlerooeric
 archives_base_name=anvilfix
 # Dependencies

--- a/src/main/java/com/googlerooeric/anvilfix/mixin/screen/AnvilScreenHandlerMixin.java
+++ b/src/main/java/com/googlerooeric/anvilfix/mixin/screen/AnvilScreenHandlerMixin.java
@@ -13,30 +13,24 @@ import net.minecraft.text.Text;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
-import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static net.minecraft.util.math.MathHelper.floor;
-
 @Mixin(AnvilScreenHandler.class)
-public abstract class AnvilScreenHandlerMixin
-        extends ForgingScreenHandler {
-
-
+public abstract class AnvilScreenHandlerMixin extends ForgingScreenHandler {
     @Shadow @Final private Property levelCost;
-
     @Shadow private int repairItemUsage;
-
     @Shadow private String newItemName;
 
     public AnvilScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context) {
         super(type, syncId, playerInventory, context);
     }
 
+    @Unique
     private static final Map<Enchantment, Integer> ENCHANTMENT_COST_MAP = new HashMap<>();
 
+    @Unique
     private static final Set<Set<Enchantment>> ENCHANTMENT_INCOMPATIBILITY_SETS = new HashSet<>();
 
     static {
@@ -61,238 +55,16 @@ public abstract class AnvilScreenHandlerMixin
         ENCHANTMENT_COST_MAP.put(Enchantments.LOOTING, 3);
         ENCHANTMENT_COST_MAP.put(Enchantments.LURE, 3);
 
+        // Populate the incompatibility sets with groups of incompatible enchantments
+        // Note: Does not include trident enchants since channeling + loyalty is valid
+        //       Does not include mending + unbreaking, since it depends on gamerule
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.SHARPNESS, Enchantments.SMITE, Enchantments.BANE_OF_ARTHROPODS));
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.PROTECTION, Enchantments.PROJECTILE_PROTECTION, Enchantments.BLAST_PROTECTION, Enchantments.FIRE_PROTECTION));
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.FORTUNE, Enchantments.SILK_TOUCH));
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.FROST_WALKER, Enchantments.DEPTH_STRIDER));
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.INFINITY, Enchantments.MENDING));
         ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.MULTISHOT, Enchantments.PIERCING));
-
-        // Loyalty and channeling are allowed together; See exception below
-        ENCHANTMENT_INCOMPATIBILITY_SETS.add(Set.of(Enchantments.LOYALTY, Enchantments.RIPTIDE, Enchantments.CHANNELING));
-
     }
-
-    private boolean areEnchantmentsIncompatible(Enchantment e1, Enchantment e2) {
-        if(e1.equals(e2)) { return false; }
-
-        // Custom exception for loyalty and channeling, which can go together
-        if(Set.of(e1, e2).containsAll(Set.of(Enchantments.LOYALTY, Enchantments.CHANNELING))) {
-            return false;
-        }
-
-        // Custom rule for mending and unbreaking because creating a new incompatibility set failed
-        if(Set.of(e1, e2).containsAll(Set.of(Enchantments.MENDING, Enchantments.UNBREAKING))) {
-            return !doesMendingWorkWithUnbreaking();
-        }
-
-        // Check if both enchants are in one incompatibility set
-        for(var set : ENCHANTMENT_INCOMPATIBILITY_SETS) {
-            if(set.contains(e1)) {
-                return set.contains(e2);
-            }
-        }
-
-        return false;
-    }
-
-    private boolean doesMendingWorkWithUnbreaking() {
-        var result = new AtomicBoolean(false);
-
-        this.context.run((world, pos) -> {
-            result.set(world.getGameRules().getBoolean(AnvilFix.MENDING_WORKS_WITH_UNBREAKING));
-        });
-
-        return result.get();
-    }
-
-    /**
-     * @author googler_ooeric
-     * @reason Fix repairing, renaming, and enchanting.
-     */
-    @Overwrite
-    public void updateResult() {
-
-        // Get the input item and initialize the level cost to 0
-        ItemStack inputItem = this.input.getStack(0);
-        this.levelCost.set(0);
-        int totalCost = 0;
-
-        // If the input item is empty, set the output to empty and return
-        if (inputItem.isEmpty()) {
-            this.output.setStack(0, ItemStack.EMPTY);
-            this.levelCost.set(0);
-            return;
-        }
-
-        // Create a copy of the input item to work on
-        ItemStack resultItem = inputItem.copy();
-
-        // Get the enchanting item (second item in the anvil)
-        ItemStack enchantingItem = this.input.getStack(1);
-
-        // Get the current enchantments on the input item
-        Map<Enchantment, Integer> currentEnchants = EnchantmentHelper.get(resultItem);
-
-        // Reset the repair item usage
-        this.repairItemUsage = 0;
-
-        // If the enchanting item isn't empty, handle enchanting/repairing
-        if (!enchantingItem.isEmpty()) {
-
-            // Check if the enchanting item and input item are enchanted books
-            boolean isEnchantedBook = enchantingItem.isOf(Items.ENCHANTED_BOOK) && !EnchantedBookItem.getEnchantmentNbt(enchantingItem).isEmpty();
-            boolean isInputItemBook = inputItem.isOf(Items.ENCHANTED_BOOK) && !EnchantedBookItem.getEnchantmentNbt(inputItem).isEmpty();
-
-
-            // If the input item is damageable and can be repaired by the second slot item, handle repairing
-            if (resultItem.isDamageable() && resultItem.getItem().canRepair(inputItem, enchantingItem)) {
-                int repairCount = 0;
-                // Calculate the amount to repair, capped at a quarter of the maximum durability
-                int repairAmount = Math.min(resultItem.getDamage(), resultItem.getMaxDamage() / 4);
-
-                // While there's still damage to repair and there are more repairing items available
-                while (repairAmount > 0 && repairCount < enchantingItem.getCount()) {
-
-                    int newDamage = resultItem.getDamage() - repairAmount;
-                    resultItem.setDamage(newDamage);
-                    totalCost += 2; // Linear cost of 2 * material amount
-                    repairAmount = Math.min(resultItem.getDamage(), resultItem.getMaxDamage() / 4);
-                    repairCount++;
-                }
-                // Why do we even need to keep repairItemUsage??? It's entirely obsolete, we don't do cost accumulation anymore
-                //TODO: get rid of repair count and repair item usage
-                this.repairItemUsage = repairCount;
-            } else {
-                // If the input item isn't a book, and the enchanting item isn't an enchanted book or the input item is not damageable, set the output to empty and return
-                if (!(isEnchantedBook || resultItem.getItem() == enchantingItem.getItem() && resultItem.isDamageable()) && !isInputItemBook) {
-                    this.output.setStack(0, ItemStack.EMPTY);
-                    this.levelCost.set(0);
-                    return;
-                }
-
-                // Get the enchantments on the enchanting item
-                Map<Enchantment, Integer> newEnchants = EnchantmentHelper.get(enchantingItem);
-
-
-                if (isInputItemBook && isEnchantedBook) // If both the input item and the enchanting item are enchanted books, handle merging
-                {
-                    Map<Enchantment, Integer> book2Enchants = new HashMap<>(newEnchants);
-                    for (Enchantment e : currentEnchants.keySet()) {
-                        if (book2Enchants.containsKey(e)) {
-                            int currentLevel = currentEnchants.get(e);
-                            int book2Level = book2Enchants.get(e);
-                            if (currentLevel <= book2Level && currentLevel + 1 <= e.getMaxLevel()) {
-                                currentEnchants.put(e, currentLevel + 1);
-                                totalCost += ENCHANTMENT_COST_MAP.getOrDefault(e, 2) * (currentLevel + 1);
-                            }
-
-                            book2Enchants.remove(e);
-                        }
-                    }
-
-                    for (Map.Entry<Enchantment, Integer> entry : book2Enchants.entrySet()) {
-                        Enchantment enchantment = entry.getKey();
-                        Integer level = entry.getValue();
-                        boolean compatible = currentEnchants.entrySet().stream()
-                                .noneMatch(existingEnchant -> areEnchantmentsIncompatible(existingEnchant.getKey(), enchantment));
-                        if (compatible) {
-                            currentEnchants.put(enchantment, level);
-                            totalCost += ENCHANTMENT_COST_MAP.getOrDefault(enchantment, 2) * level;
-                        }
-                    }
-                }
-                else // If the input item is not an enchanted book, handle regular enchanting
-                {
-
-
-                    for (Enchantment enchantment : newEnchants.keySet()) {
-                        if (enchantment == null) continue;
-
-                        int currentLevel = currentEnchants.getOrDefault(enchantment, 0);
-                        int newLevel = newEnchants.getOrDefault(enchantment, 0);
-                        int finalLevel;
-
-                        // If the current level and new level are the same, increment the final level
-                        if (currentLevel <= newLevel && currentLevel < enchantment.getMaxLevel()) {
-                            finalLevel = currentLevel + 1;
-                        } else {
-                            finalLevel = Math.max(newLevel, currentLevel);
-                        }
-
-                        // If enchantment is acceptable on item
-                        if (enchantment.isAcceptableItem(inputItem)) {
-
-                            // Check for incompatible enchantments
-                            boolean hasIncompatibleEnchantments = currentEnchants.keySet().stream()
-                                    .anyMatch(enchant -> areEnchantmentsIncompatible(enchantment, enchant));
-
-                            // If there are no incompatible enchantments, add the enchantment
-                            if(!hasIncompatibleEnchantments){
-                                if(currentEnchants.containsKey(enchantment) && finalLevel > currentEnchants.get(enchantment)){
-                                    totalCost += ENCHANTMENT_COST_MAP.getOrDefault(enchantment, 2) * finalLevel;
-                                } else if(!currentEnchants.containsKey(enchantment)){
-                                    totalCost += ENCHANTMENT_COST_MAP.getOrDefault(enchantment, 2) * Math.max(finalLevel, newLevel);
-                                }
-                                // What the fuck???
-                                currentEnchants.put(enchantment, Math.max(finalLevel, newLevel));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Riiise anddd shiinee, Mister Freeman.
-        // Rise and... shine. Not that I... wish to imply you have been... sleeping, on the job.
-        // No one is more *deserving* of a rest... and all the effort in the worrrllldd would have gone to waste, until...
-        // Well... let's just say your hour has... come again.
-        // The right man in the wrong place, can make *all* the diff-erence in the worldd...
-        // So, wake up, Mister Freeman... Wake up and, smell the ashesssss
-
-        // If the enchanting item is empty and the new name is null or the same as the input item's name, set the output to empty and return
-        if (enchantingItem.isEmpty() && (this.newItemName == null || this.newItemName.equals(inputItem.getName().getString()))){
-            this.output.setStack(0, ItemStack.EMPTY);
-            this.levelCost.set(0);
-            return;
-        }
-
-        // If the new name is blank and the input item has a custom name, remove the custom name and add the cost
-        if (StringUtils.isBlank(this.newItemName) || this.newItemName == null) {
-            if(inputItem.hasCustomName()){
-                totalCost += 2;
-                resultItem.removeCustomName();
-            }
-        }
-        // If the new name is not null and different from the input item's name, set the custom name and add the cost
-        else if (this.newItemName != null && !this.newItemName.equals(inputItem.getName().getString())) {
-            totalCost += 2; // Renaming always costs 2 xp
-            resultItem.setCustomName(Text.literal(this.newItemName));
-        }
-
-
-        // Set the level cost to the total cost
-        this.levelCost.set(totalCost);
-
-        // If the total cost is 0 or less, set the result item to empty
-        if (totalCost <= 0) {
-            resultItem = ItemStack.EMPTY;
-        }
-
-        // If the result item isn't empty, set the repair cost and enchantments
-        if (!resultItem.isEmpty()) {
-            int repairCost = Math.max(resultItem.getRepairCost(), enchantingItem.isEmpty() ? 0 : enchantingItem.getRepairCost());
-            resultItem.setRepairCost(repairCost);
-            EnchantmentHelper.set(currentEnchants, resultItem);
-        }
-
-        // Set the output stack to the result item and send updates
-        this.output.setStack(0, resultItem);
-        this.sendContentUpdates();
-    }
-
-
-
 
     /**
      * @author googler_ooeric
@@ -303,4 +75,207 @@ public abstract class AnvilScreenHandlerMixin
         return cost; // Return the cost as it is
     }
 
+    /**
+     * @author DavidMacDonald11
+     * @reason Change how anvils work to make more sense
+     */
+    @Overwrite
+    public void updateResult() {
+        var item = this.input.getStack(0);
+        var totalCost = 0;
+
+        if(item.isEmpty()) {
+            this.output.setStack(0, ItemStack.EMPTY);
+            this.levelCost.set(0);
+            return;
+        }
+
+        this.repairItemUsage = 0;
+        var modifier = this.input.getStack(1);
+        var result = item.copy();
+
+        if(!modifier.isEmpty()) {
+            totalCost += repairAndEnchantItem(item, modifier, result);
+        }
+
+        totalCost += renameItem(item, result, modifier.isEmpty(), totalCost);
+        setFinalResult(totalCost, result);
+    }
+
+    @Unique
+    private int repairAndEnchantItem(ItemStack item, ItemStack modifier, ItemStack result) {
+        if(canItemBeRepairedByModifier(item, modifier)) {
+            return repairItem(item, modifier, result);
+        }
+
+        var itemIsBook = isItemAnEnchantedBook(item);
+        var modifierIsBook = isItemAnEnchantedBook(modifier);
+
+        if(!itemIsBook && !modifierIsBook) {
+            return mergeItems(item, modifier, result);
+        }
+
+        if(modifierIsBook) {
+            return addEnchantsToItem(item, modifier, result);
+        }
+
+        return 0;
+    }
+
+    @Unique
+    private int renameItem(ItemStack item, ItemStack result, boolean modifierIsEmpty, int cost) {
+        if(!modifierIsEmpty && cost == 0) { return 0; }
+
+        if(StringUtils.isBlank(this.newItemName) || this.newItemName == null) {
+            if(item.hasCustomName()) {
+                result.removeCustomName();
+                return 2;
+            }
+
+            return 0;
+        }
+
+        if(this.newItemName.equals(item.getName().getString())) { return 0; }
+
+        result.setCustomName(Text.literal(this.newItemName));
+        return 2;
+    }
+
+    @Unique
+    private void setFinalResult(int totalCost,  ItemStack result) {
+        if(totalCost == 0) {
+            result = ItemStack.EMPTY;
+        }
+
+        this.levelCost.set(totalCost);
+        this.output.setStack(0, result);
+        this.sendContentUpdates();
+    }
+
+    @Unique
+    private static boolean canItemBeRepairedByModifier(ItemStack first, ItemStack second) {
+        return first.isDamageable() && first.getItem().canRepair(first, second);
+    }
+
+    @Unique
+    private static boolean isItemAnEnchantedBook(ItemStack item) {
+        return item.isOf(Items.ENCHANTED_BOOK) && !EnchantedBookItem.getEnchantmentNbt(item).isEmpty();
+    }
+
+    @Unique
+    private int repairItem(ItemStack item, ItemStack modifier, ItemStack result) {
+        var damage = item.getDamage();
+        var damageReductionPerRepair = item.getMaxDamage() / 4;
+
+        var desiredRepairs = (int)Math.ceil((double)damage / damageReductionPerRepair);
+        var possibleRepairs = modifier.getCount();
+        var repairs = Math.min(desiredRepairs, possibleRepairs);
+
+        var maxDamageReduction = repairs * damageReductionPerRepair;
+        var damageReduction = Math.min(damage, maxDamageReduction);
+
+        result.setDamage(damage - damageReduction);
+        this.repairItemUsage = repairs;
+
+        return 2 * repairs;
+    }
+
+    @Unique
+    private int mergeItems(ItemStack item, ItemStack modifier, ItemStack result) {
+        if(!ItemStack.areItemsEqualIgnoreDamage(item, modifier)) { return 0; }
+        var totalCost = addEnchantsToItem(item, modifier, result);
+
+        var maxHealth = item.getMaxDamage();
+        var itemHealth = maxHealth - item.getDamage();
+        var modifierHealth = maxHealth - modifier.getDamage();
+
+        if(itemHealth != maxHealth) {
+            var combinedHealth = (int)(itemHealth + modifierHealth + maxHealth * .12);
+            var newHealth = Math.min(maxHealth, combinedHealth);
+
+            result.setDamage(maxHealth - newHealth);
+            totalCost += 2;
+        }
+
+        return totalCost;
+    }
+
+    @Unique
+    private int addEnchantsToItem(ItemStack item, ItemStack modifier, ItemStack result) {
+        var enchants = new HashMap<>(EnchantmentHelper.get(item));
+
+        var itemIsBook = isItemAnEnchantedBook(item);
+        var newEnchants = EnchantmentHelper.get(modifier);
+        var totalCost = 0;
+
+        for(var newEnchant : newEnchants.keySet()) {
+            if(!itemIsBook && !newEnchant.isAcceptableItem(item)) {
+                continue;
+            }
+
+            int newLevel = newEnchants.get(newEnchant);
+
+            if(enchants.containsKey(newEnchant)) {
+                totalCost += mergeEnchantmentLevels(enchants, newEnchant, newLevel);
+            } else {
+                totalCost += addNewEnchantment(enchants, newEnchant, newLevel);
+            }
+        }
+
+        EnchantmentHelper.set(enchants, result);
+        return totalCost;
+    }
+
+    @Unique
+    private int mergeEnchantmentLevels(Map<Enchantment, Integer> enchants, Enchantment newEnchant, int newLevel) {
+        int level = enchants.get(newEnchant);
+        if(level == newLevel && level < newEnchant.getMaxLevel()) { newLevel++; }
+
+        if(level < newLevel) {
+            enchants.put(newEnchant, newLevel);
+            return ENCHANTMENT_COST_MAP.getOrDefault(newEnchant, 2) * newLevel;
+        }
+
+        return 0;
+    }
+
+    @Unique
+    private int addNewEnchantment(Map<Enchantment, Integer> enchants, Enchantment newEnchant, int newLevel) {
+        var incompatibilitySet = getIncompatibiltySet(newEnchant);
+        var enchantKeys = enchants.keySet();
+
+        if(Collections.disjoint(enchantKeys, incompatibilitySet)) {
+            enchants.put(newEnchant, newLevel);
+            return ENCHANTMENT_COST_MAP.getOrDefault(newEnchant, 2) * newLevel;
+        }
+
+        return 0;
+    }
+
+    @Unique
+    private Set<Enchantment> getIncompatibiltySet(Enchantment enchant) {
+        var specialTridentEnchants = Set.of(Enchantments.CHANNELING, Enchantments.LOYALTY);
+
+        if(specialTridentEnchants.contains(enchant)) { return Set.of(Enchantments.RIPTIDE); }
+        if(enchant.equals(Enchantments.RIPTIDE)) { return specialTridentEnchants; }
+
+        if(!doesMendingWorkWithUnbreaking()) {
+            if(enchant.equals(Enchantments.MENDING)) { return Set.of(Enchantments.UNBREAKING); }
+            if(enchant.equals(Enchantments.UNBREAKING)) { return Set.of(Enchantments.MENDING); }
+        }
+
+        for(var set : ENCHANTMENT_INCOMPATIBILITY_SETS) {
+            if(set.contains(enchant)) { return set; }
+        }
+
+        return Set.of();
+    }
+
+    @Unique
+    private boolean doesMendingWorkWithUnbreaking() {
+        var result = new AtomicBoolean(false);
+        this.context.run((world, pos) -> result.set(world.getGameRules().getBoolean(AnvilFix.MENDING_WORKS_WITH_UNBREAKING)));
+
+        return result.get();
+    }
 }


### PR DESCRIPTION
I rewrote the code for the sake of organization. I fixed four bugs:

1. I added rules to prevent incompatible enchantment combination for all enchantments. Instead of using a map, I created a group  of sets of incompatibility ex. The set of Sharpness, Smite, and Bane of Arthropods. This works fine for all incompatible sets except trident enchantments, because Riptide is not compatible with Channeling or Loyalty, but Channeling is compatible with Loyalty. There is a custom rule to handle that, as well as Mending + Unbreaking depending on the gamerule.
2. When combining tools/armor together with low durability, the resulting item did not gain any durability. I believe this is a bug rather than an intentional choice, so I added logic to merge durability like in vanilla. It seems the equation is floor(leftDurability + rightDurability + 12% (maxDurability)), capped to maxDurability of course.  If the durability is increased, I add 2 to the level cost for the enchant.
3. When repairing items with materials, if you place more items than necessary, the anvil will consume the entire stack rather than only the required amount like in vanilla. I used the repairItemUsage variable built into the class to avoid this; If it takes 3 diamonds to repair and you place 17 in, you will keep 14 after the repair.
4. In vanilla, if you combine, lets say, two brand new unenchanted pickaxes in an anvil, it will not allow you to do this. However, if you rename it, now you can perform the rename and delete the second item. The same applies for books, etc. I think this is ridiculous, so I added a rule that does not allow you to rename at the item in this situation. The user must simply remove the secondary item to rename.

Feel free to make any requests or to modify my changes as you see fit. Thanks!
Fixes [Issue 3](https://github.com/googleooer/AnvilFix-issues/issues/3)